### PR TITLE
Removed index on fulltext message field

### DIFF
--- a/Config/Schema/schema.php
+++ b/Config/Schema/schema.php
@@ -30,7 +30,6 @@ class DatabaseLogSchema extends CakeSchema {
 		'indexes' => array(
 			'PRIMARY' => array('column' => 'id', 'unique' => 1),
 			'type' => array('column' => 'type', 'unique' => 0),
-			'message' => array('column' => 'message', 'type' => 'fulltext')
 		),
 		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_general_ci', 'engine' => 'MyISAM')
 	);


### PR DESCRIPTION
Because SQL Server doesn't like that.

You can't specify a field bigger than 900 bytes to be poart of an index:
http://stackoverflow.com/questions/2863993/is-of-a-type-that-is-invalid-for-use-as-a-key-column-in-an-index

This change makes saving the logs faster, which is - im most cases- more common than reading them.
