### PR TITLE
Pagination fix

### DIFF
--- a/src/Controller/Admin/LogsController.php
+++ b/src/Controller/Admin/LogsController.php
@@ -38,7 +38,7 @@ class LogsController extends AppController {
 	 * @var array
 	 */
 	public $paginate = [
-		'order' => ['DatabaseLogs.id' => 'DESC'],
+		'order' => ['DatabaseLogs.created' => 'DESC'],
 		'fields' => [
 			'DatabaseLogs.created',
 			'DatabaseLogs.type',
@@ -62,9 +62,6 @@ class LogsController extends AppController {
 			$conditions['type'] = $type;
 		}
 		$query = $this->DatabaseLogs->find()->where($conditions);
-		$this->paginate = [
-			'order' => ['created' => 'DESC'],
-		];
 
 		$this->set('logs', $this->paginate($query));
 		$this->set('logType', $type);

--- a/src/Shell/DatabaseLogShell.php
+++ b/src/Shell/DatabaseLogShell.php
@@ -66,7 +66,7 @@ class DatabaseLogShell extends Shell {
 			$limit = (int)$elements[1];
 		}
 
-		/* @var \DatabaseLog\Model\Entity\DatabaseLog[] $logs */
+		/** @var \DatabaseLog\Model\Entity\DatabaseLog[] $logs */
 		$logs = $query->order(['created' => 'DESC'])
 			->limit($limit)
 			->offset($offset)
@@ -106,7 +106,7 @@ class DatabaseLogShell extends Shell {
 		foreach ($types as $type) {
 			$query = $this->DatabaseLogs->find();
 
-			/* @var \DatabaseLog\Model\Entity\DatabaseLog[] $logs */
+			/** @var \DatabaseLog\Model\Entity\DatabaseLog[] $logs */
 			$logs = $query->where(['type' => $type])
 				->limit($limit)
 				->order(['created' => 'DESC'])


### PR DESCRIPTION
With this patch it is possible to overwrite pagination options
from the child classes.  For example:

```
<?php
namespace App\Controller;

use DatabaseLog\Controller\Admin\LogsController as BaseController;

class LogsController extends BaseController
{
    public function initialize()
    {
        parent::initialize();
        $this->paginate['limit'] = 5;
    }
}
```