### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,13 @@ composer require dereuromark/cakephp-databaselog
 ```
 
 ## Setup
-Enable the plugin in your `config/bootstrap.php` or call
+Enable the plugin in your `config/bootstrap.php`:
+ ```php
+ Plugin::load('DatabaseLog', ['bootstrap' => true]);
+ ```
+or just call:
 ```
-bin/cake plugin load DatabaseLog
+bin/cake plugin load DatabaseLog -b
 ```
 
 You can simply modify the existing config entries in your `config/app.php`:


### PR DESCRIPTION
We tried using the plugin with just the default settings (loading the plugin and changing the entries in config/app.php as described in README.md). It didn't work, kept telling me that "datasource configuration "database_log" was not found." I figured out that we would need to add said datasource configuration and that this is done in your bootstrap file, which therefore should be included when loading the plugin.