### PR TITLE
Altering URI field

### DIFF
--- a/config/Migrations/20180103140215_AlterDatabaseLogs.php
+++ b/config/Migrations/20180103140215_AlterDatabaseLogs.php
@@ -1,0 +1,22 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AlterDatabaseLogs extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('database_logs');
+		$table->changeColumn('uri', 'text', [
+			'default' => null,
+			'null' => true,
+		]);
+        $table->update();
+    }
+}

--- a/config/Migrations/20180103140215_AlterDatabaseLogs.php
+++ b/config/Migrations/20180103140215_AlterDatabaseLogs.php
@@ -13,10 +13,10 @@ class AlterDatabaseLogs extends AbstractMigration
     public function change()
     {
         $table = $this->table('database_logs');
-		$table->changeColumn('uri', 'text', [
-			'default' => null,
-			'null' => true,
-		]);
+        $table->changeColumn('uri', 'text', [
+            'default' => null,
+            'null' => true,
+        ]);
         $table->update();
     }
 }


### PR DESCRIPTION
JavaScript DataTables plugin uses GET request by default to perform AJAX calls for loading table content. In certain occassions it started hitting VARCHAR(255) column limits.

> SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'uri'

As a quick fix, we can alter 'uri' column into text, that will let us store longer URI's in the table.
  