### PR TITLE
Skip Database table creation

### DIFF
--- a/config/Migrations/20161005230232_InitDatabaseLogs.php
+++ b/config/Migrations/20161005230232_InitDatabaseLogs.php
@@ -13,6 +13,10 @@ class InitDatabaseLogs extends AbstractMigration {
 	 * @return void
 	 */
 	public function up() {
+		if ($this->hasTable('database_logs')) {
+			return;
+		}
+
 		$this->table('database_logs')
 			->addColumn('type', 'string', [
 				'default' => null,


### PR DESCRIPTION
This PR fixes migration failure if `\DatabaseLog\Model\Table\DatabaseLogsTable` is loaded before the migrations are run.

Database table is being created automatically whenever the aforementioned class is loaded, to ensure the schema exists in the current connection.