### PR TITLE
Removed the Ordering

### DIFF
--- a/src/Controller/Admin/DatabaseLogController.php
+++ b/src/Controller/Admin/DatabaseLogController.php
@@ -46,7 +46,6 @@ class DatabaseLogController extends AppController {
 			->select(['summary'])
 			->where(['type' => 'error'])
 			->group('summary')
-			->orderDesc('id')
 			->limit(10)
 			->disableHydration()
 			->all()->toArray();

--- a/src/Controller/Admin/DatabaseLogController.php
+++ b/src/Controller/Admin/DatabaseLogController.php
@@ -46,6 +46,7 @@ class DatabaseLogController extends AppController {
 			->select(['summary'])
 			->where(['type' => 'error'])
 			->group('summary')
+			->orderDesc('MAX(id)')
 			->limit(10)
 			->disableHydration()
 			->all()->toArray();


### PR DESCRIPTION
When I attempt to visit this page I receive an error 
`Error: SQLSTATE[42000]: Syntax error or access violation: 1055 Expression #1 of ORDER BY clause is not in GROUP BY clause and contains nonaggregated column 'MYSCHEMA.DatabaseLogs.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by`