### PR TITLE
Ensure LOGS dir exists and is writable for sqlite fallback

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -14,23 +14,24 @@ if (!$connection) {
 	}
 	if (!$hasDatabaseLogConfig) {
 		if (!is_dir(LOGS)) {
-			mkdir(LOGS, 0770, true);
+			@mkdir(LOGS, 0770, true);
 		}
 		if (!is_writable(LOGS)) {
-			throw new InternalErrorException(
+			trigger_error(
 				sprintf('The `DatabaseLog` sqlite fallback requires the `%s` directory to be writable, ', LOGS)
 				. 'or define the `connection` name in the `DatabaseLog` config.',
+				E_USER_WARNING,
 			);
+		} else {
+			ConnectionManager::setConfig('database_log', [
+				'className' => 'Cake\Database\Connection',
+				'driver' => 'Cake\Database\Driver\Sqlite',
+				'database' => LOGS . 'database_log.sqlite',
+				'encoding' => 'utf8mb4',
+				'cacheMetadata' => true,
+				'quoteIdentifiers' => false,
+			]);
 		}
-
-		ConnectionManager::setConfig('database_log', [
-			'className' => 'Cake\Database\Connection',
-			'driver' => 'Cake\Database\Driver\Sqlite',
-			'database' => LOGS . 'database_log.sqlite',
-			'encoding' => 'utf8mb4',
-			'cacheMetadata' => true,
-			'quoteIdentifiers' => false,
-		]);
 	}
 }
 

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -13,6 +13,16 @@ if (!$connection) {
 			. 'or define the `connection` name in the `DatabaseLog` config.');
 	}
 	if (!$hasDatabaseLogConfig) {
+		if (!is_dir(LOGS)) {
+			mkdir(LOGS, 0770, true);
+		}
+		if (!is_writable(LOGS)) {
+			throw new InternalErrorException(
+				sprintf('The `DatabaseLog` sqlite fallback requires the `%s` directory to be writable, ', LOGS)
+				. 'or define the `connection` name in the `DatabaseLog` config.',
+			);
+		}
+
 		ConnectionManager::setConfig('database_log', [
 			'className' => 'Cake\Database\Connection',
 			'driver' => 'Cake\Database\Driver\Sqlite',


### PR DESCRIPTION
## Summary

Fixes #58.

The sqlite fallback connection in `config/bootstrap.php` silently failed on staging/production when the `LOGS` directory was missing or not writable — the existing `mkdir(LOGS)` call was gated on `debug` mode, so non-debug environments got a cryptic error instead of the auto-configured connection.

The fallback now:

- Creates `LOGS` if missing (unconditional on debug, only when actually using the fallback).
- If `LOGS` still isn't writable, emits an `E_USER_WARNING` and **skips** `setConfig()` rather than throwing. A logging plugin shouldn't take down the host app — any code that actually tries to use the `database_log` connection will fail later with a clearer message, and apps that don't exercise the logger at boot keep running.