### PR TITLE
Make backend route path configurable

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * DatabaseLog (Default) Configuration
+ * DatabaseLog Example Configuration
  *
  * Copy this content to your config/app.php
  * and customize it to your needs.
@@ -13,6 +13,9 @@ use DatabaseLog\Model\Entity\DatabaseLog;
 return [
 	'DatabaseLog' => [
 		'connection' => null, // Connection to use, 'default' will use your live DB instead of SQLite
+
+		// Backend routing (opt-in; defaults to /database-log for BC)
+		'routePath' => '/database-log', // Path segment mounted under /admin (e.g. '/logs' for /admin/logs)
 
 		// Admin dashboard options
 		'standalone' => false, // Set to true for isolated admin that doesn't depend on the host app

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,15 @@ The `limit` config defaults to `999999` as basic protection. The `maxLength` is 
 Navigate to `http://your-domain.local/admin/database-log/logs` to view/search/delete your logs.
 Make sure you loaded your plugin with `'routes' => true'` in that case.
 
+### Customizing the backend URL
+The default backend path is `/admin/database-log`. You can change the path segment via Configure:
+```php
+'DatabaseLog' => [
+    'routePath' => '/logs', // Results in /admin/logs
+],
+```
+This is opt-in to keep existing URLs backwards compatible. In the next major version the default will change to `/logs`.
+
 You can customize the template with a custom theme if necessary.
 
 You can also adjust the label colors of the log types with Configure and

--- a/src/DatabaseLogPlugin.php
+++ b/src/DatabaseLogPlugin.php
@@ -4,6 +4,7 @@ namespace DatabaseLog;
 
 use Cake\Console\CommandCollection;
 use Cake\Core\BasePlugin;
+use Cake\Core\Configure;
 use Cake\Routing\RouteBuilder;
 use DatabaseLog\Command\CleanupCommand;
 use DatabaseLog\Command\ExportCommand;
@@ -26,8 +27,9 @@ class DatabaseLogPlugin extends BasePlugin {
 	 * @return void
 	 */
 	public function routes(RouteBuilder $routes): void {
-		$routes->prefix('Admin', function (RouteBuilder $routes): void {
-			$routes->plugin('DatabaseLog', ['path' => '/database-log'], function (RouteBuilder $routes): void {
+		$path = Configure::read('DatabaseLog.routePath', '/database-log');
+		$routes->prefix('Admin', function (RouteBuilder $routes) use ($path): void {
+			$routes->plugin('DatabaseLog', ['path' => $path], function (RouteBuilder $routes): void {
 				$routes->connect('/', ['controller' => 'DatabaseLog', 'action' => 'index']);
 
 				$routes->fallbacks();

--- a/tests/TestCase/Controller/DatabaseLogControllerTest.php
+++ b/tests/TestCase/Controller/DatabaseLogControllerTest.php
@@ -12,6 +12,7 @@ namespace DatabaseLog\Test\TestCase\Controller;
 
 use Cake\Database\Driver\Postgres;
 use Cake\ORM\TableRegistry;
+use Cake\Routing\Router;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 
@@ -65,6 +66,22 @@ class DatabaseLogControllerTest extends TestCase {
 
 		$this->assertResponseNotEmpty();
 		$this->assertResponseCode(200);
+	}
+
+	/**
+	 * Ensures the default backend path remains `/admin/database-log` (BC).
+	 *
+	 * @return void
+	 */
+	public function testDefaultRoutePath() {
+		$url = Router::url([
+			'prefix' => 'Admin',
+			'plugin' => 'DatabaseLog',
+			'controller' => 'DatabaseLog',
+			'action' => 'index',
+		]);
+
+		$this->assertSame('/admin/database-log', $url);
 	}
 
 }


### PR DESCRIPTION
## Summary

Adds a `DatabaseLog.routePath` Configure option so the admin backend can be mounted at a custom path segment. Defaults to the existing `/database-log` to preserve backwards compatibility — this is opt-in.

Groundwork for #60: users who want the shorter `/admin/logs` URL today can opt in via:

```php
'DatabaseLog' => [
    'routePath' => '/logs',
],
```

In the next major version the default can be flipped to `/logs` (or the config dropped entirely).

## Notes

- Zero BC impact: default behavior unchanged.
- Added a test asserting `Router::url()` still resolves to `/admin/database-log` by default.
- Docs updated under *Backend View*.