### PR TITLE
Make admin UI CSP-compatible (nonce inline scripts, drop inline onclick)

### DIFF
--- a/templates/Admin/DatabaseLog/index.php
+++ b/templates/Admin/DatabaseLog/index.php
@@ -144,9 +144,13 @@ $chartColors = [
 <?php endif; ?>
 
 <?php if (!empty($stats['datasets'])): ?>
-<?php $this->append('script'); ?>
+<?php
+$this->append('script');
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
+$nonceAttr = $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '';
+?>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
-<script>
+<script<?= $nonceAttr ?>>
 document.addEventListener('DOMContentLoaded', function() {
 	var ctx = document.getElementById('logActivityChart').getContext('2d');
 	var chartData = <?= json_encode($stats) ?>;

--- a/templates/Admin/Logs/index.php
+++ b/templates/Admin/Logs/index.php
@@ -17,14 +17,16 @@ use DatabaseLog\Model\Table\DatabaseLogsTable;
 	</h1>
 	<?php if ($currentType): ?>
 	<div>
-		<?= $this->Form->postLink(
+		<?= $this->Form->postButton(
 			'<i class="fas fa-trash me-1"></i>' . __d('database_log', 'Reset {0} Logs', '"' . $currentType . '"'),
 			['action' => 'reset', '?' => ['type' => $currentType]],
 			[
 				'class' => 'btn btn-outline-danger btn-sm',
 				'escapeTitle' => false,
-				'confirm' => __d('database_log', 'Delete all {0} logs? This cannot be undone.', $currentType),
-				'block' => true,
+				'form' => [
+					'class' => 'd-inline',
+					'data-confirm-message' => __d('database_log', 'Delete all {0} logs? This cannot be undone.', $currentType),
+				],
 			]
 		) ?>
 	</div>
@@ -109,15 +111,17 @@ use DatabaseLog\Model\Table\DatabaseLogsTable;
 							<a href="<?= $this->Url->build(['action' => 'view', $log->id, '?' => $this->request->getQuery()]) ?>" class="btn btn-outline-primary" title="<?= __d('database_log', 'View') ?>">
 								<i class="fas fa-eye"></i>
 							</a>
-							<?= $this->Form->postLink(
+							<?= $this->Form->postButton(
 								'<i class="fas fa-trash"></i>',
 								['action' => 'delete', $log->id],
 								[
 									'class' => 'btn btn-outline-danger',
 									'escapeTitle' => false,
-									'confirm' => __d('database_log', 'Delete log #{0}?', $log->id),
 									'title' => __d('database_log', 'Delete'),
-									'block' => true,
+									'form' => [
+										'class' => 'd-inline',
+										'data-confirm-message' => __d('database_log', 'Delete log #{0}?', $log->id),
+									],
 								]
 							) ?>
 						</div>

--- a/templates/Admin/Logs/view.php
+++ b/templates/Admin/Logs/view.php
@@ -14,7 +14,7 @@ $formatted = $this->request->getQuery('formatted');
 		<?= __d('database_log', 'Log') ?> #<?= h($log->id) ?>
 	</h1>
 	<div>
-		<button type="button" class="btn btn-outline-secondary btn-sm" onclick="copyFullLog()" title="<?= __d('database_log', 'Copy full log') ?>">
+		<button type="button" class="btn btn-outline-secondary btn-sm" data-action="copy-full-log" title="<?= __d('database_log', 'Copy full log') ?>">
 			<i class="fas fa-copy me-1"></i>
 			<?= __d('database_log', 'Copy All') ?>
 		</button>
@@ -33,14 +33,16 @@ $formatted = $this->request->getQuery('formatted');
 			<i class="fas fa-arrow-left me-1"></i>
 			<?= __d('database_log', 'Back') ?>
 		</a>
-		<?= $this->Form->postLink(
+		<?= $this->Form->postButton(
 			'<i class="fas fa-trash me-1"></i>' . __d('database_log', 'Delete'),
 			['action' => 'delete', $log->id],
 			[
 				'class' => 'btn btn-outline-danger btn-sm',
 				'escapeTitle' => false,
-				'confirm' => __d('database_log', 'Delete this log entry?'),
-				'block' => true,
+				'form' => [
+					'class' => 'd-inline',
+					'data-confirm-message' => __d('database_log', 'Delete this log entry?'),
+				],
 			]
 		) ?>
 	</div>
@@ -145,8 +147,11 @@ $formatted = $this->request->getQuery('formatted');
 </div>
 <?php endif; ?>
 
-<?php $this->append('script'); ?>
-<script>
+<?php
+$this->append('script');
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
+?>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 // Copy individual section
 document.querySelectorAll('.copy-btn').forEach(function(btn) {
 	btn.addEventListener('click', function() {
@@ -158,8 +163,8 @@ document.querySelectorAll('.copy-btn').forEach(function(btn) {
 	});
 });
 
-// Copy full log
-function copyFullLog() {
+// Copy full log (triggered by button[data-action="copy-full-log"])
+function copyFullLog(btn) {
 	var fullLog = <?= json_encode([
 		'id' => $log->id,
 		'type' => $log->type,
@@ -182,8 +187,14 @@ function copyFullLog() {
 		text += "\n--- Context ---\n" + fullLog.context + "\n";
 	}
 
-	copyToClipboard(text, document.querySelector('[onclick="copyFullLog()"]'));
+	copyToClipboard(text, btn);
 }
+
+document.querySelectorAll('[data-action="copy-full-log"]').forEach(function(btn) {
+	btn.addEventListener('click', function() {
+		copyFullLog(this);
+	});
+});
 
 function copyToClipboard(text, btn) {
 	navigator.clipboard.writeText(text).then(function() {

--- a/templates/element/DatabaseLog/sidebar.php
+++ b/templates/element/DatabaseLog/sidebar.php
@@ -39,34 +39,40 @@ $isActive = function (string $c, ?array $actions = null) use ($controller, $acti
 	<div class="nav-section">
 		<div class="nav-section-title"><?= __d('database_log', 'Quick Actions') ?></div>
 		<nav class="nav flex-column">
-			<?= $this->Form->postLink(
+			<?= $this->Form->postButton(
 				'<i class="fas fa-compress-alt"></i> ' . __d('database_log', 'Remove Duplicates'),
 				['plugin' => 'DatabaseLog', 'prefix' => 'Admin', 'controller' => 'Logs', 'action' => 'removeDuplicates'],
 				[
-					'class' => 'nav-link',
+					'class' => 'nav-link btn btn-link text-start w-100',
 					'escapeTitle' => false,
-					'confirm' => __d('database_log', 'Remove all duplicate log entries?'),
-					'block' => true,
+					'form' => [
+						'class' => 'd-inline',
+						'data-confirm-message' => __d('database_log', 'Remove all duplicate log entries?'),
+					],
 				]
 			) ?>
-			<?= $this->Form->postLink(
+			<?= $this->Form->postButton(
 				'<i class="fas fa-compress"></i> ' . __d('database_log', 'Remove Duplicates (strict)'),
 				['plugin' => 'DatabaseLog', 'prefix' => 'Admin', 'controller' => 'Logs', 'action' => 'removeDuplicates', '?' => ['strict' => true]],
 				[
-					'class' => 'nav-link',
+					'class' => 'nav-link btn btn-link text-start w-100',
 					'escapeTitle' => false,
-					'confirm' => __d('database_log', 'Remove all duplicate log entries (strict mode)?'),
-					'block' => true,
+					'form' => [
+						'class' => 'd-inline',
+						'data-confirm-message' => __d('database_log', 'Remove all duplicate log entries (strict mode)?'),
+					],
 				]
 			) ?>
-			<?= $this->Form->postLink(
+			<?= $this->Form->postButton(
 				'<i class="fas fa-trash"></i> ' . __d('database_log', 'Reset All Logs'),
 				['plugin' => 'DatabaseLog', 'prefix' => 'Admin', 'controller' => 'Logs', 'action' => 'reset'],
 				[
-					'class' => 'nav-link text-warning',
+					'class' => 'nav-link text-warning btn btn-link text-start w-100',
 					'escapeTitle' => false,
-					'confirm' => __d('database_log', 'Delete all log entries? This cannot be undone.'),
-					'block' => true,
+					'form' => [
+						'class' => 'd-inline',
+						'data-confirm-message' => __d('database_log', 'Delete all log entries? This cannot be undone.'),
+					],
 				]
 			) ?>
 		</nav>

--- a/templates/layout/database_log.php
+++ b/templates/layout/database_log.php
@@ -15,6 +15,8 @@ $request = $this->getRequest();
 if ($request && $request->getParam('controller') === 'DatabaseLog' && $request->getParam('action') === 'index') {
 	$autoRefresh = (int)Configure::read('DatabaseLog.dashboardAutoRefresh') ?: 0;
 }
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
+$nonceAttr = $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '';
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -278,7 +280,7 @@ if ($request && $request->getParam('controller') === 'DatabaseLog' && $request->
 			</a>
 
 			<!-- Mobile toggle -->
-			<button class="navbar-toggler dblog-mobile-toggle d-lg-none" type="button" onclick="document.querySelector('.dblog-sidebar').classList.toggle('show')">
+			<button class="navbar-toggler dblog-mobile-toggle d-lg-none" type="button" data-action="toggle-sidebar">
 				<i class="fas fa-bars"></i>
 			</button>
 		</div>
@@ -301,12 +303,32 @@ if ($request && $request->getParam('controller') === 'DatabaseLog' && $request->
 	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 
 	<?php if ($autoRefresh > 0): ?>
-	<script>
+	<script<?= $nonceAttr ?>>
 		setTimeout(function() {
 			window.location.reload();
 		}, <?= $autoRefresh * 1000 ?>);
 	</script>
 	<?php endif; ?>
+
+	<script<?= $nonceAttr ?>>
+	document.addEventListener('DOMContentLoaded', function() {
+		// Mobile sidebar toggle (CSP-safe replacement for inline onclick)
+		document.querySelectorAll('[data-action="toggle-sidebar"]').forEach(function(btn) {
+			btn.addEventListener('click', function() {
+				document.querySelector('.dblog-sidebar').classList.toggle('show');
+			});
+		});
+
+		// Confirmation dialogs for postButton forms (CSP-safe replacement for postLink + confirm)
+		document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
+			form.addEventListener('submit', function(e) {
+				if (!confirm(this.dataset.confirmMessage)) {
+					e.preventDefault();
+				}
+			});
+		});
+	});
+	</script>
 
 	<?= $this->fetch('script') ?>
 	<?= $this->fetch('postLink') ?>


### PR DESCRIPTION
## Summary

- Add `nonce` attribute to the three inline `<script>` blocks (layout auto-refresh reload, stats chart on the dashboard, copy-clipboard helpers on the log view) plus one new layout DOMContentLoaded block, so apps with a strict `script-src 'self' 'nonce-...' ...` CSP can run them.
- Replace the layout mobile-sidebar `onclick="document.querySelector('.dblog-sidebar').classList.toggle('show')"` with a `data-action="toggle-sidebar"` attribute + delegated listener in the layout script.
- Replace the 'Copy All' `onclick="copyFullLog()"` on `Logs/view` with a `data-action="copy-full-log"` attribute + delegated listener in the same script block.
- Replace every `Form->postLink` across the admin templates (Logs/view delete, Logs/index reset + per-row delete, sidebar element remove-duplicates / remove-duplicates-strict / reset-all) with `Form->postButton`. Move the `'confirm'` message to a `form[data-confirm-message]` data attribute, handled by a delegated submit listener in the layout.

## Motivation

Inline event handlers (`onclick=`, `onchange=`, ...) are blocked under a strict CSP without `'unsafe-inline'` / `'unsafe-hashes'`. Per the CSP spec, the `nonce` directive does **not** cover inline event handlers — only inline `<script>`/`<style>` blocks. And `postLink` emits `onclick="document.getElementById('post_X').submit()"` on the `<a>`, which triggers the same block.

Also note: passing `'confirm' => X` to `postButton` re-introduces an inline `onclick` on the button, so confirm messages have to migrate to a `data-*` attribute and a delegated submit handler.

## Before / after

```diff
- <?= $this->Form->postLink(
-     '<i class="fas fa-trash me-1"></i>' . __d('database_log', 'Delete'),
-     ['action' => 'delete', $log->id],
-     [
-         'class' => 'btn btn-outline-danger btn-sm',
-         'escapeTitle' => false,
-         'confirm' => __d('database_log', 'Delete this log entry?'),
-         'block' => true,
-     ]
- ) ?>
+ <?= $this->Form->postButton(
+     '<i class="fas fa-trash me-1"></i>' . __d('database_log', 'Delete'),
+     ['action' => 'delete', $log->id],
+     [
+         'class' => 'btn btn-outline-danger btn-sm',
+         'escapeTitle' => false,
+         'form' => [
+             'class' => 'd-inline',
+             'data-confirm-message' => __d('database_log', 'Delete this log entry?'),
+         ],
+     ]
+ ) ?>
```

And the delegate at the end of `templates/layout/database_log.php`:

```php
<script<?= $nonceAttr ?>>
document.addEventListener('DOMContentLoaded', function() {
    document.querySelectorAll('[data-action="toggle-sidebar"]').forEach(function(btn) {
        btn.addEventListener('click', function() {
            document.querySelector('.dblog-sidebar').classList.toggle('show');
        });
    });

    document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
        form.addEventListener('submit', function(e) {
            if (!confirm(this.dataset.confirmMessage)) {
                e.preventDefault();
            }
        });
    });
});
</script>
```

## Host app nonce setup

Apps that want to benefit from the new nonce support need to set a `cspNonce` request attribute in a middleware, for example:

```php
$nonce = base64_encode(random_bytes(16));
$request = $request->withAttribute('cspNonce', $nonce);
$response = $response->withHeader(
    'Content-Security-Policy',
    "script-src 'self' 'nonce-{$nonce}'"
);
```

If no `cspNonce` attribute is present, the `<script>` tags fall back to rendering without the `nonce` attribute — apps on permissive CSP continue to work unchanged.

## Visual side-note

The Logs index per-row action column was a Bootstrap `.btn-group` wrapping a view `<a>` + delete `postLink`. Because `postButton` now wraps its button in `<form class="d-inline">`, the btn-group no longer collapses borders across the form boundary. The two buttons render as independent adjacent buttons rather than a connected group. Functionally identical; visual grouping lost. Mentioning for awareness.

## Verified

- Template grep: 0 `Form->postLink` calls, 0 inline `on*=` event handlers, 0 un-nonced inline `<script>` blocks.
- Behaviour unchanged: delete / reset / remove-duplicates still prompt before firing the POST; mobile sidebar toggle still works; full-log copy button still works.