### PR TITLE
Use escapeTitle in pagination element

### DIFF
--- a/templates/element/paging.php
+++ b/templates/element/paging.php
@@ -25,11 +25,11 @@ $this->Paginator->setTemplates([
 ?>
 <nav class="mt-4 pt-2" aria-label="<?= __d('database_log', 'Page navigation') ?>">
 	<ul class="pagination justify-content-center mb-2">
-		<?= $this->Paginator->first('<i class="fas fa-angle-double-left"></i>', ['escape' => false]) ?>
-		<?= $this->Paginator->prev('<i class="fas fa-angle-left"></i>', ['escape' => false]) ?>
+		<?= $this->Paginator->first('<i class="fas fa-angle-double-left"></i>', ['escapeTitle' => false]) ?>
+		<?= $this->Paginator->prev('<i class="fas fa-angle-left"></i>', ['escapeTitle' => false]) ?>
 		<?= $this->Paginator->numbers() ?>
-		<?= $this->Paginator->next('<i class="fas fa-angle-right"></i>', ['escape' => false]) ?>
-		<?= $this->Paginator->last('<i class="fas fa-angle-double-right"></i>', ['escape' => false]) ?>
+		<?= $this->Paginator->next('<i class="fas fa-angle-right"></i>', ['escapeTitle' => false]) ?>
+		<?= $this->Paginator->last('<i class="fas fa-angle-double-right"></i>', ['escapeTitle' => false]) ?>
 	</ul>
 	<p class="text-center text-muted small">
 		<?= $this->Paginator->counter(__d('database_log', 'Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total')) ?>


### PR DESCRIPTION
Using `'escape' => false` on Paginator helpers also disables HTML escaping of attributes (URL, class, title attr), not just the title text. The narrower `'escapeTitle' => false` keeps attribute escaping on while still allowing the icon markup in the title.

Affects `templates/element/paging.php` only.

| Before | After |
|---|---|
| `['escape' => false]` | `['escapeTitle' => false]` |

Defense-in-depth — no known exploit path because the call sites pass static strings, but keeping the strict default protects against future edits that wire dynamic values into pagination options.
