### PR TITLE
Fix textSearch alias and sanitize export filename

### DIFF
--- a/src/Command/ExportCommand.php
+++ b/src/Command/ExportCommand.php
@@ -35,6 +35,13 @@ class ExportCommand extends Command {
 		$limit = (int)$args->getOption('limit') ?: 100;
 
 		foreach ($types as $type) {
+			$safeType = preg_replace('/[^a-zA-Z0-9_-]/', '_', (string)$type);
+			if ($safeType === '' || $safeType === null) {
+				$io->warning('Skipping type with empty/invalid name.');
+
+				continue;
+			}
+
 			$query = $this->fetchTable('DatabaseLog.DatabaseLogs')->find();
 
 			/** @var array<\DatabaseLog\Model\Entity\DatabaseLog> $logs */
@@ -50,9 +57,9 @@ class ExportCommand extends Command {
 			}
 
 			$content = implode(PHP_EOL, $contentArray);
-			file_put_contents(LOGS . 'export-' . $type . '.txt', $content);
+			file_put_contents(LOGS . 'export-' . $safeType . '.txt', $content);
 
-			$io->success('Exporting type ' . $type . ': ' . count($logs) . ' entries written to export-' . $type . '.txt');
+			$io->success('Exporting type ' . $type . ': ' . count($logs) . ' entries written to export-' . $safeType . '.txt');
 		}
 
 		if (!$types) {

--- a/src/Model/Table/DatabaseLogsTable.php
+++ b/src/Model/Table/DatabaseLogsTable.php
@@ -164,10 +164,10 @@ class DatabaseLogsTable extends DatabaseLogAppTable {
 	 */
 	public function textSearch($query = null) {
 		if ($query) {
-			if (str_contains($query, 'type@') && strpos($query, 'type@') === 0) {
+			if (str_starts_with($query, 'type@')) {
 				$query = str_replace('type@', '', $query);
 
-				return ['Log.type' => $query];
+				return [$this->aliasField('type') => $query];
 			}
 
 			// Use proper escaping for fulltext search

--- a/tests/TestCase/Model/Table/DatabaseLogsTableTest.php
+++ b/tests/TestCase/Model/Table/DatabaseLogsTableTest.php
@@ -106,10 +106,10 @@ class DatabaseLogsTableTest extends TestCase {
 	 */
 	public function testTextSearch() {
 		$res = $this->Logs->textSearch('interesting');
-		$this->assertEquals(['MATCH (message) AGAINST (\'interesting\')'], $res);
+		$this->assertSame(['MATCH (message) AGAINST (\'interesting\')'], $res);
 
 		$res = $this->Logs->textSearch('type@foo');
-		$this->assertEquals(['Log.type' => 'foo'], $res);
+		$this->assertSame(['DatabaseLogs.type' => 'foo'], $res);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- textSearch() returned conditions keyed on 'Log.type', but the table alias is 'DatabaseLogs', so the typed-field search syntax (type<at>foo) hits an unknown alias and raises a SQL error at runtime. Switch to aliasField('type') so the condition resolves correctly, and update the hard-coded test expectation that was masking the bug.
- ExportCommand wrote files via LOGS . 'export-' . type . '.txt' with no sanitization. A CLI 'type' argument like '../etc/passwd-fake' could escape the LOGS directory. Whitelist the filename component to [a-zA-Z0-9_-] before composing the path; the original 'type' value is still used for the WHERE clause and user-facing output.

## Files

- src/Model/Table/DatabaseLogsTable.php
- src/Command/ExportCommand.php
- tests/TestCase/Model/Table/DatabaseLogsTableTest.php