### PR TITLE
Add server clock to admin header

### DIFF
--- a/templates/layout/database_log.php
+++ b/templates/layout/database_log.php
@@ -279,6 +279,11 @@ $nonceAttr = $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '';
 				DatabaseLog
 			</a>
 
+			<span class="text-light small ms-auto me-3" title="<?= __d('database_log', 'Server Time') ?>">
+				<i class="far fa-clock me-1"></i>
+				<?= date('Y-m-d H:i:s') ?>
+			</span>
+
 			<!-- Mobile toggle -->
 			<button class="navbar-toggler dblog-mobile-toggle d-lg-none" type="button" data-action="toggle-sidebar">
 				<i class="fas fa-bars"></i>


### PR DESCRIPTION
Single span with the server time tucked between the brand and the mobile toggle, mirroring the Queue / AuditStash / Bouncer admin headers.