### PR TITLE
Use plugin-specific i18n domain for translations

### DIFF
--- a/resources/locales/database_log.pot
+++ b/resources/locales/database_log.pot
@@ -1,0 +1,193 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2026-05-04 04:12+0200\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+msgid "DatabaseLog admin backend is not configured. Set DatabaseLog.adminAccess to a Closure that returns true for permitted callers."
+msgstr ""
+
+msgid "DatabaseLog admin access denied."
+msgstr ""
+
+msgid "Log deleted"
+msgstr ""
+
+msgid "Log was not deleted"
+msgstr ""
+
+msgid "Duplicates have been removed."
+msgstr ""
+
+msgid "Dashboard"
+msgstr ""
+
+msgid "Logs Table"
+msgstr ""
+
+msgid "No log entries found."
+msgstr ""
+
+msgid "Log Activity"
+msgstr ""
+
+msgid "24h"
+msgstr ""
+
+msgid "7 days"
+msgstr ""
+
+msgid "30 days"
+msgstr ""
+
+msgid "No data for this period."
+msgstr ""
+
+msgid "Last Errors"
+msgstr ""
+
+msgid "View All Errors"
+msgstr ""
+
+msgid "Logs"
+msgstr ""
+
+msgid "Reset {0} Logs"
+msgstr ""
+
+msgid "Delete all {0} logs? This cannot be undone."
+msgstr ""
+
+msgid "All"
+msgstr ""
+
+msgid "Created"
+msgstr ""
+
+msgid "Type"
+msgstr ""
+
+msgid "Summary"
+msgstr ""
+
+msgid "Actions"
+msgstr ""
+
+msgid "View"
+msgstr ""
+
+msgid "Delete"
+msgstr ""
+
+msgid "Delete log #{0}?"
+msgstr ""
+
+msgid "Log"
+msgstr ""
+
+msgid "Copy full log"
+msgstr ""
+
+msgid "Copy All"
+msgstr ""
+
+msgid "Normal"
+msgstr ""
+
+msgid "Formatted"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+msgid "Delete this log entry?"
+msgstr ""
+
+msgid "Details"
+msgstr ""
+
+msgid "Command"
+msgstr ""
+
+msgid "URI"
+msgstr ""
+
+msgid "Referrer"
+msgstr ""
+
+msgid "Hostname"
+msgstr ""
+
+msgid "IP"
+msgstr ""
+
+msgid "User Agent"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Message"
+msgstr ""
+
+msgid "Context"
+msgstr ""
+
+msgid "Navigation"
+msgstr ""
+
+msgid "Quick Actions"
+msgstr ""
+
+msgid "Remove Duplicates"
+msgstr ""
+
+msgid "Remove all duplicate log entries?"
+msgstr ""
+
+msgid "Remove Duplicates (strict)"
+msgstr ""
+
+msgid "Remove all duplicate log entries (strict mode)?"
+msgstr ""
+
+msgid "Reset All Logs"
+msgstr ""
+
+msgid "Delete all log entries? This cannot be undone."
+msgstr ""
+
+msgid "Page navigation"
+msgstr ""
+
+msgid "Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total"
+msgstr ""
+
+msgid "Auto-wildcard mode"
+msgstr ""
+
+msgid "Search (Summary)"
+msgstr ""
+
+msgid "- no filter -"
+msgstr ""
+
+msgid "Filter"
+msgstr ""
+
+msgid "Reset"
+msgstr ""
+
+msgid "Server Time"
+msgstr ""
+

--- a/src/Controller/Admin/LogsController.php
+++ b/src/Controller/Admin/LogsController.php
@@ -91,11 +91,11 @@ class LogsController extends DatabaseLogAppController {
 		$log = $this->DatabaseLogs->get($id);
 
 		if ($this->DatabaseLogs->delete($log)) {
-			$this->Flash->success(__('Log deleted'));
+			$this->Flash->success(__d('database_log', 'Log deleted'));
 
 			return $this->redirect(['action' => 'index']);
 		}
-		$this->Flash->error(__('Log was not deleted'));
+		$this->Flash->error(__d('database_log', 'Log was not deleted'));
 
 		return $this->redirect(['action' => 'index']);
 	}
@@ -132,7 +132,7 @@ class LogsController extends DatabaseLogAppController {
 
 		$this->DatabaseLogs->removeDuplicates((bool)$this->request->getQuery('strict'));
 
-		$this->Flash->success(__('Duplicates have been removed.'));
+		$this->Flash->success(__d('database_log', 'Duplicates have been removed.'));
 
 		return $this->redirect(['action' => 'index']);
 	}


### PR DESCRIPTION
## Summary

- Convert the 3 `__()` calls in `src/Controller/Admin/LogsController.php` (Flash messages on log delete + duplicate cleanup) to `__d('database_log', ...)`. The 66 pre-existing `__d('database_log', ...)` calls already pointed at the right domain — the rest of the plugin now matches.
- Add `resources/locales/database_log.pot` (59 unique msgids) generated via `bin/cake i18n extract`.

## Why

Three Flash messages on the admin log-management actions were landing in the host app's `default` domain instead of the plugin's. Anyone building a German/Japanese/etc. language pack for the plugin's admin UI would have ended up with those three strings untranslated.

## Verification (local)

- phpunit: 36 / 36
- phpstan: no errors
- phpcs: clean