### PR TITLE
Add configurable Back-to-App link to admin header

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -23,6 +23,14 @@ return [
 		'adminLayout' => null, // null = plugin layout, false = app layout, string = custom layout
 		'dashboardAutoRefresh' => 0, // Auto-refresh interval in seconds (0 = disabled)
 
+		// Back-to-App link in the admin header (opt-in). When set, an outline
+		// "Back to App" button appears in the header so admins can escape the
+		// plugin-isolated layout. Accepts anything Router::url() takes — Cake
+		// URL array, path string, or full URL. Use 'plugin' => false to
+		// anchor the builder to the host app.
+		// 'adminBackUrl' => ['plugin' => false, 'prefix' => 'Admin', 'controller' => 'Overview', 'action' => 'index'],
+		// 'adminBackLabel' => 'Back to admin', // Optional. Defaults to "Back to App".
+
 		// Admin access gate. REQUIRED — the host app MUST set this to a Closure
 		// that returns true to grant access to /admin/database-log/...; anything
 		// else (unset, non-Closure, returns false, returns a truthy non-bool, or

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,32 @@ The `limit` config defaults to `999999` as basic protection. The `maxLength` is 
 Navigate to `http://your-domain.local/admin/database-log/logs` to view/search/delete your logs.
 Make sure you loaded your plugin with `'routes' => true'` in that case.
 
+### Back-to-App link (`DatabaseLog.adminBackUrl`, optional)
+
+When set, an outline "Back to App" button appears in the admin header
+between the brand and the clock — gives admins a one-click escape from
+the plugin-isolated layout back to the host app's admin home.
+
+`adminBackUrl` accepts anything `Router::url()` accepts: a Cake URL
+array, a path string, or a full URL. Use `'plugin' => false` to anchor
+the URL builder to the host app rather than the plugin's namespace.
+`adminBackLabel` is optional and defaults to `"Back to App"` (translated
+through the `database_log` domain).
+
+```php
+'DatabaseLog' => [
+    'adminBackUrl' => [
+        'plugin' => false,
+        'prefix' => 'Admin',
+        'controller' => 'Overview',
+        'action' => 'index',
+    ],
+    'adminBackLabel' => __('Back to admin'), // optional
+],
+```
+
+When unset (the default), the button is hidden.
+
 ### Authorization (`DatabaseLog.adminAccess`, required)
 
 Log entries commonly contain sensitive data (stack traces with credentials,

--- a/templates/layout/database_log.php
+++ b/templates/layout/database_log.php
@@ -279,12 +279,24 @@ $nonceAttr = $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '';
 				DatabaseLog
 			</a>
 
+			<?php
+			$adminBackUrl = Configure::read('DatabaseLog.adminBackUrl');
+			$hasAdminBack = $adminBackUrl !== null && $adminBackUrl !== '';
+			$adminBackLabel = (string)Configure::read('DatabaseLog.adminBackLabel', __d('database_log', 'Back to App'));
+			?>
+			<?php if ($hasAdminBack) { ?>
+			<a class="btn btn-outline-light btn-sm ms-auto" href="<?= $this->Url->build($adminBackUrl) ?>">
+				<i class="fas fa-arrow-left me-1"></i>
+				<?= h($adminBackLabel) ?>
+			</a>
+			<?php } ?>
+
 			<!-- Mobile toggle -->
-			<button class="navbar-toggler dblog-mobile-toggle d-lg-none ms-auto" type="button" data-action="toggle-sidebar">
+			<button class="navbar-toggler dblog-mobile-toggle d-lg-none <?= $hasAdminBack ? 'ms-2' : 'ms-auto' ?>" type="button" data-action="toggle-sidebar">
 				<i class="fas fa-bars"></i>
 			</button>
 
-			<span class="text-light small ms-lg-auto ms-3" title="<?= __d('database_log', 'Server Time') ?>">
+			<span class="text-light small <?= $hasAdminBack ? 'ms-3' : 'ms-lg-auto ms-3' ?>" title="<?= __d('database_log', 'Server Time') ?>">
 				<i class="far fa-clock me-1"></i>
 				<?= date('Y-m-d H:i:s') ?>
 			</span>


### PR DESCRIPTION
Configurable Back-to-App link in the admin header. Reads `<Plugin>.adminBackUrl` (any URL — string, array, anything `$this->Url->build()` accepts). Optional `<Plugin>.adminBackLabel` overrides the default "Back to App" text. Hidden by default — set the URL to opt in.

Same shape across cakephp-audit-stash, cakephp-bouncer, and cakephp-databaselog so hosts loading multiple plugins set them with consistent config.