### PR TITLE
Pretty print context json

### DIFF
--- a/src/Model/Table/DatabaseLogsTable.php
+++ b/src/Model/Table/DatabaseLogsTable.php
@@ -88,7 +88,7 @@ class DatabaseLogsTable extends DatabaseLogAppTable {
 	public function log($level, $message, array $context = []) {
 		$message = trim($message);
 		$summary = Text::truncate($message, 255);
-		$context = json_encode($context, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '';
+		$context = json_encode($context, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT) ?: '';
 
 		if (mb_strlen($message) > 65535) {
 			$message = mb_substr($message, 0, 65535);


### PR DESCRIPTION
To make more use of the "Formatted" view, json should be created using JSON_PRETTY_PRINT. This might be worse for performance, but better for understanding the log in the admin view. In the past, print_r was used. By switching to json any formatting was unfortunately gone.